### PR TITLE
support Camel-cased method

### DIFF
--- a/lib/ruremai/locator/rurema.rb
+++ b/lib/ruremai/locator/rurema.rb
@@ -10,7 +10,7 @@ module Ruremai
 
         def candidates
           uri_part    = [RUBY_VERSION, 'method', owner.name.gsub(/::/, '/')].join('/')
-          method_name = CGI.escape(name.to_s).gsub(/%/, '=').downcase # XXX
+          method_name = CGI.escape(name.to_s).gsub(/%/, '=') # XXX
 
           %w(i s m).map {|type|
             URI.parse("#{uri_base}/#{uri_part}/#{type}/#{method_name}.html")


### PR DESCRIPTION
Support camel case method (such as [`Kernel.Integer`](http://doc.ruby-lang.org/ja/1.9.3/method/Kernel/m/Integer.html)).
